### PR TITLE
Changed assets to shares into RedeemRequest

### DIFF
--- a/ERCS/erc-7540.md
+++ b/ERCS/erc-7540.md
@@ -325,7 +325,7 @@ MUST be emitted when a redemption Request is submitted using the `requestRedeem`
     - name: sender
       indexed: false
       type: uint256
-    - name: assets
+    - name: shares
       indexed: false
       type: uint256
 ```


### PR DESCRIPTION
I propose to update the `RedeemRequest` event. The last entry can be renamed `shares`.
Although shares are an asset and the current `asset` term may seem correct, it is confusing as it could make you think that you want to predict the amount of the underlying asset you plan to withdraw through your redemption request and pass this value into the current `asset` input of the `RedeemRequest` event.
In addition, I think this is more consistent with the erc-4626 name.